### PR TITLE
Make Travis 💚 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
       before_install:
         - which ${CXX}
     - os: linux
-      env: CXX=clang++ CXXFLAGS="-flto"
+      env: CXX=clang++ LINKER_FLAGS="-flto" CXXFLAGS="-flto"
       addons:
         apt:
           sources: [ 'ubuntu-toolchain-r-test' ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,21 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} $ENV{LINKER_FLAGS}")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} $ENV{LINKER_FLAGS}")
 set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} $ENV{LINKER_FLAGS}")
 
+# clang LTO requires using llvm-ar and llvm-ranlib
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  find_program(LLVM_AR llvm-ar)
+  find_program(LLVM_RANLIB llvm-ranlib)
+  if ("${LLVM_AR}" STREQUAL "LLVM_AR-NOTFOUND" OR "${LLVM_RANLIB}" STREQUAL "LLVM_RANLIB-NOTFOUND")
+    message(WARNING "LLVM specific binutils not found.")
+  else()
+    message(STATUS "Using LLVM specific binutils for LTO:")
+    message(STATUS " ${LLVM_AR}")
+    message(STATUS " ${LLVM_RANLIB}")
+    set(CMAKE_AR ${LLVM_AR})
+    set(CMAKE_RANLIB ${LLVM_RANLIB})
+  endif()
+endif()
+
 file(GLOB_RECURSE Sources src src/*.cpp)
 
 add_library(spatialalgorithms STATIC ${Sources})


### PR DESCRIPTION
This addresses #3. I'm not planning on developing on the C++ code actively. But I've spent a lot of time getting things like link time optimization working with cmake with OSRM, so I've added my knowledge get to get this working.

Main changes:

  - Passed `-flto` to both the compile and link flags (might be better ways to do this, but this works)
  - Enables `llvm-ar` and `llvm-ranlib` which are needed for `-flto` linking to work.
  - Combines the sanitizer job to run both `address` and `undefined` in one job because why not? (I only recently learned you could pass multiple sanitizers to the `-fsanitize` option)
  - Makes the sanitizer job Debug to enable better stack traces if we ever hit bugs
  - Only installs `binutils` on linux: it is needed on linux for `-flto` but not needed on OS X where the default linker supports `-flto` out of the box.