### PR TITLE
Build with c++11 flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 project(spatialalgorithms LANGUAGES CXX C)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 
 option(BUILD_EXAMPLES "Build examples ON/OFF(default)" OFF)

--- a/cmake/spatialalgorithms.cmake
+++ b/cmake/spatialalgorithms.cmake
@@ -5,5 +5,5 @@ execute_process(
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 
 # CMake 3.1 does not have this yet.
-set(CMAKE_CXX14_STANDARD_COMPILE_OPTION "-std=c++14")
-set(CMAKE_CXX14_EXTENSION_COMPILE_OPTION "-std=gnu++14")
+set(CMAKE_CXX11_STANDARD_COMPILE_OPTION "-std=c++11")
+set(CMAKE_CXX11_EXTENSION_COMPILE_OPTION "-std=gnu++11")

--- a/include/mapbox/geometry/algorithms/closest_point.hpp
+++ b/include/mapbox/geometry/algorithms/closest_point.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mapbox/geometry/point.hpp>
+
 namespace mapbox { namespace geometry { namespace algorithms {
 
 template <typename T>

--- a/include/mapbox/geometry/algorithms/closest_point_impl.hpp
+++ b/include/mapbox/geometry/algorithms/closest_point_impl.hpp
@@ -1,4 +1,4 @@
-#include <mapbox/geometry.hpp>
+#include <mapbox/geometry/geometry.hpp>
 #include <mapbox/geometry/algorithms/detail/boost_adapters.hpp>
 #include <mapbox/geometry/algorithms/closest_point.hpp>
 #include <boost/geometry/extensions/algorithms/closest_point.hpp>

--- a/include/mapbox/geometry/algorithms/detail/boost_adapters.hpp
+++ b/include/mapbox/geometry/algorithms/detail/boost_adapters.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 // mapbox
-#include <mapbox/geometry.hpp>
+#include <mapbox/geometry/geometry.hpp>
 #include <mapbox/geometry/box.hpp>
 // boost.geometry
 #include <boost/geometry/geometry.hpp>

--- a/include/mapbox/geometry/algorithms/detail/predicate_dispatcher.hpp
+++ b/include/mapbox/geometry/algorithms/detail/predicate_dispatcher.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <type_traits>
+#include <mapbox/geometry/geometry.hpp>
+
 namespace mapbox { namespace geometry { namespace algorithms { namespace detail {
 
 template <typename T>

--- a/include/mapbox/geometry/algorithms/intersection.hpp
+++ b/include/mapbox/geometry/algorithms/intersection.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mapbox/geometry/geometry.hpp>
+#include <mapbox/geometry/box.hpp>
 #include <vector>
 
 namespace mapbox { namespace geometry { namespace algorithms {

--- a/include/mapbox/geometry/algorithms/intersection_impl.hpp
+++ b/include/mapbox/geometry/algorithms/intersection_impl.hpp
@@ -1,4 +1,4 @@
-#include <mapbox/geometry.hpp>
+#include <mapbox/geometry/geometry.hpp>
 #include <mapbox/geometry/box.hpp>
 #include <mapbox/geometry/algorithms/detail/boost_adapters.hpp>
 #include <mapbox/geometry/algorithms/intersection.hpp>

--- a/include/mapbox/geometry/algorithms/predicates/disjoint_impl.hpp
+++ b/include/mapbox/geometry/algorithms/predicates/disjoint_impl.hpp
@@ -1,5 +1,5 @@
 //
-#include <mapbox/geometry.hpp>
+#include <mapbox/geometry/geometry.hpp>
 #include <mapbox/geometry/algorithms/detail/boost_adapters.hpp>
 #include <mapbox/geometry/algorithms/detail/predicate_dispatcher.hpp>
 #include <mapbox/geometry/algorithms/predicates/disjoint.hpp>

--- a/include/mapbox/geometry/algorithms/predicates/intersects_impl.hpp
+++ b/include/mapbox/geometry/algorithms/predicates/intersects_impl.hpp
@@ -1,5 +1,5 @@
 //
-#include <mapbox/geometry.hpp>
+#include <mapbox/geometry/geometry.hpp>
 #include <mapbox/geometry/algorithms/detail/boost_adapters.hpp>
 #include <mapbox/geometry/algorithms/detail/predicate_dispatcher.hpp>
 #include <mapbox/geometry/algorithms/predicates/intersects.hpp>

--- a/include/mapbox/geometry/algorithms/scaling_impl.hpp
+++ b/include/mapbox/geometry/algorithms/scaling_impl.hpp
@@ -1,4 +1,4 @@
-#include <mapbox/geometry.hpp>
+#include <mapbox/geometry/geometry.hpp>
 #include <mapbox/geometry/algorithms/detail/boost_adapters.hpp>
 #include <mapbox/geometry/algorithms/scaling.hpp>
 #include <boost/geometry/algorithms/transform.hpp>

--- a/test/test-spatial-algorithms.cpp
+++ b/test/test-spatial-algorithms.cpp
@@ -1,4 +1,4 @@
-#include <mapbox/geometry.hpp>
+#include <mapbox/geometry/geometry.hpp>
 #include <mapbox/geometry/algorithms/predicates.hpp>
 #include <iostream>
 

--- a/test/unit/closest_point/test-closest-point.cpp
+++ b/test/unit/closest_point/test-closest-point.cpp
@@ -1,5 +1,5 @@
 #include <boost/test/unit_test.hpp>
-#include <mapbox/geometry.hpp>
+#include <mapbox/geometry/geometry.hpp>
 #include <mapbox/geometry/algorithms/closest_point.hpp>
 #include <iostream>
 BOOST_AUTO_TEST_SUITE(closest_point_tests)

--- a/test/unit/intersection/test-intersection.cpp
+++ b/test/unit/intersection/test-intersection.cpp
@@ -1,5 +1,6 @@
 #include <boost/test/unit_test.hpp>
-#include <mapbox/geometry.hpp>
+#include <mapbox/geometry/geometry.hpp>
+#include <mapbox/geometry/box.hpp>
 #include <mapbox/geometry/algorithms/intersection.hpp>
 #include <iostream>
 BOOST_AUTO_TEST_SUITE(intersection_tests)

--- a/test/unit/predicates/test-disjoint.cpp
+++ b/test/unit/predicates/test-disjoint.cpp
@@ -1,5 +1,5 @@
 #include <boost/test/unit_test.hpp>
-#include <mapbox/geometry.hpp>
+#include <mapbox/geometry/geometry.hpp>
 #include <mapbox/geometry/algorithms/predicates.hpp>
 #include <iostream>
 

--- a/test/unit/predicates/test-intersects.cpp
+++ b/test/unit/predicates/test-intersects.cpp
@@ -1,5 +1,5 @@
 #include <boost/test/unit_test.hpp>
-#include <mapbox/geometry.hpp>
+#include <mapbox/geometry/geometry.hpp>
 #include <mapbox/geometry/algorithms/predicates.hpp>
 #include <iostream>
 

--- a/test/unit/scaling/test-scaling.cpp
+++ b/test/unit/scaling/test-scaling.cpp
@@ -1,7 +1,8 @@
 #include <boost/test/unit_test.hpp>
-#include <mapbox/geometry.hpp>
+#include <mapbox/geometry/geometry.hpp>
 #include <mapbox/geometry/algorithms/scaling.hpp>
 #include <iostream>
+#include <cmath>
 
 BOOST_AUTO_TEST_SUITE(scaling_tests)
 


### PR DESCRIPTION
Unless c++14 is absolutely needed, we should stick to building/testing/supporting C++11.

I took a look at whether all the tests would build and pass in C++11. They do - the only thing requiring C++14 was the `#include <mapbox/geometry.hpp>` that indirectly pulled in `mapbox/geometry/feature.hpp` which pulls in `std::experimental::optional` from https://github.com/mapbox/geometry.hpp/blob/b0e41cc5635ff8d50e7e1edb73cadf1d2a7ddc83/include/mapbox/geometry/feature.hpp#L11.

Ideally, in my view `geometry.hpp` would be configured in such a way that `std::experimental::optional` is not forced on downstream users. Until this is fixed, simply using `#include <mapbox/geometry/geometry.hpp>` solves the problem elegantly and allows us to build in C++11 mode.

