### PR TITLE
[WIP] an approach to ease local dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,14 +4,22 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 
 option(BUILD_EXAMPLES "Build examples ON/OFF(default)" OFF)
+option(ENABLE_MASON   "Use mason for dependencies" OFF)
 
 include(cmake/spatialalgorithms.cmake)
-include(cmake/mason.cmake)
 
-mason_use(boost VERSION 1.63.0 HEADER_ONLY)
-mason_use(geometry VERSION 0.9.0 HEADER_ONLY)
-mason_use(variant VERSION 1.1.4 HEADER_ONLY)
-mason_use(wagyu VERSION 0.4.1 HEADER_ONLY)
+if(ENABLE_MASON)
+    include(cmake/mason.cmake)
+    mason_use(boost VERSION 1.63.0 HEADER_ONLY)
+    mason_use(geometry VERSION 0.9.0 HEADER_ONLY)
+    mason_use(variant VERSION 1.1.4 HEADER_ONLY)
+    set(SA_INCLUDE_DIRS ${MASON_PACKAGE_boost_INCLUDE_DIRS} ${MASON_PACKAGE_geometry_INCLUDE_DIRS} ${MASON_PACKAGE_variant_INCLUDE_DIRS})
+else()
+    # local dev: assume variant and geometry.hpp are checked out into ../
+    # look everywhere for boost
+    find_package(Boost 1.53 REQUIRED COMPONENTS ${BOOST_COMPONENTS})
+    set(SA_INCLUDE_DIRS ${Boost_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}/../variant/include ${CMAKE_CURRENT_SOURCE_DIR}/../geometry.hpp/include)
+endif()
 
 include_directories("${PROJECT_SOURCE_DIR}/include")
 
@@ -37,26 +45,17 @@ endif()
 file(GLOB_RECURSE Sources src src/*.cpp)
 
 add_library(spatialalgorithms STATIC ${Sources})
-target_include_directories(spatialalgorithms SYSTEM PRIVATE ${MASON_PACKAGE_boost_INCLUDE_DIRS})
-target_include_directories(spatialalgorithms SYSTEM PUBLIC ${MASON_PACKAGE_geometry_INCLUDE_DIRS})
-target_include_directories(spatialalgorithms SYSTEM PRIVATE ${MASON_PACKAGE_wagyu_INCLUDE_DIRS})
-target_include_directories(spatialalgorithms SYSTEM PUBLIC ${MASON_PACKAGE_variant_INCLUDE_DIRS})
+target_include_directories(spatialalgorithms SYSTEM PRIVATE ${SA_INCLUDE_DIRS})
 
 if(BUILD_EXAMPLES)
 add_executable(hello-spatial-algorithms examples/hello-spatial-algorithms.cpp)
-target_include_directories(hello-spatial-algorithms SYSTEM PRIVATE ${MASON_PACKAGE_boost_INCLUDE_DIRS})
-target_include_directories(hello-spatial-algorithms SYSTEM PUBLIC ${MASON_PACKAGE_geometry_INCLUDE_DIRS})
-target_include_directories(hello-spatial-algorithms SYSTEM PRIVATE ${MASON_PACKAGE_wagyu_INCLUDE_DIRS})
-target_include_directories(hello-spatial-algorithms SYSTEM PUBLIC ${MASON_PACKAGE_variant_INCLUDE_DIRS})
+target_include_directories(hello-spatial-algorithms SYSTEM PRIVATE ${SA_INCLUDE_DIRS})
 target_link_libraries(hello-spatial-algorithms spatialalgorithms)
 endif(BUILD_EXAMPLES)
 
 file(GLOB_RECURSE Test_Sources test/unit test/unit/*.cpp)
 add_executable(test_sa ${Test_Sources})
-target_include_directories(test_sa SYSTEM PRIVATE ${MASON_PACKAGE_boost_INCLUDE_DIRS})
-target_include_directories(test_sa SYSTEM PUBLIC ${MASON_PACKAGE_geometry_INCLUDE_DIRS})
-target_include_directories(test_sa SYSTEM PRIVATE ${MASON_PACKAGE_wagyu_INCLUDE_DIRS})
-target_include_directories(test_sa SYSTEM PUBLIC ${MASON_PACKAGE_variant_INCLUDE_DIRS})
+target_include_directories(test_sa SYSTEM PRIVATE ${SA_INCLUDE_DIRS})
 target_link_libraries(test_sa spatialalgorithms)
 
 install(DIRECTORY include DESTINATION .


### PR DESCRIPTION
This allows you to configure whether we use pinned versions of deps from mason (good for stability and reliable builds) or whether a dev wants to point at local packages (good for fast iteration). It assumes you've checked out master of `variant` and `geometry.hpp` (and other deps in the future) to the same directory as spatial-algorithms. This could be extended to accept an option to point to them in some other, custom, location. But for now this seems simplest to get something going where you can opt out of mason packages.

Not ready for merging: more for testing a discussion. /cc @flippmoke 