### PR TITLE
operator for empty geometry types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ include(cmake/spatialalgorithms.cmake)
 include(cmake/mason.cmake)
 
 mason_use(boost VERSION 1.63.0 HEADER_ONLY)
-mason_use(geometry VERSION 0.9.0 HEADER_ONLY)
+mason_use(geometry VERSION 96d3505 HEADER_ONLY)
 mason_use(variant VERSION 1.1.4 HEADER_ONLY)
 mason_use(wagyu VERSION 0.4.1 HEADER_ONLY)
 

--- a/include/mapbox/geometry/algorithms/closest_point.hpp
+++ b/include/mapbox/geometry/algorithms/closest_point.hpp
@@ -17,4 +17,5 @@ struct closest_point_info
 
 template <typename T1, typename T2>
 closest_point_info closest_point(T1 const& geom, mapbox::geometry::point<T2> const& pt);
+
 }}}

--- a/include/mapbox/geometry/algorithms/closest_point_impl.hpp
+++ b/include/mapbox/geometry/algorithms/closest_point_impl.hpp
@@ -16,6 +16,10 @@ struct closest_point
     closest_point(mapbox::geometry::point<coordinate_type> const& pt)
         : pt_(pt) {}
 
+    result_type operator() (mapbox::geometry::empty) const {
+        return result_type();
+    }
+
     result_type operator() (mapbox::geometry::point<coordinate_type> const& pt) const
     {
         info_type info;

--- a/include/mapbox/geometry/algorithms/closest_point_impl.hpp
+++ b/include/mapbox/geometry/algorithms/closest_point_impl.hpp
@@ -74,17 +74,19 @@ struct closest_point
         {
             if (first)
             {
-                first = false;
                 result = std::move(operator()(geom));
-                if (boost::geometry::math::equals(result.distance, 0.0))
-                {
-                    return result;
+                if (!(result.distance < 0.0)) {
+                    first = false;
+                    if (boost::geometry::math::equals(result.distance, 0.0))
+                    {
+                        return result;
+                    }
                 }
             }
             else
             {
                 auto sub_result = operator()(geom);
-                if (sub_result.distance < result.distance)
+                if (sub_result.distance < result.distance && !(sub_result.distance < 0.0))
                 {
                     result = std::move(sub_result);
                 }

--- a/src/closest_point_d.cpp
+++ b/src/closest_point_d.cpp
@@ -4,6 +4,7 @@
 
 namespace mapbox { namespace geometry { namespace algorithms {
 
+template closest_point_info closest_point(empty const&, point<double> const&);
 template closest_point_info closest_point(geometry<double> const&, point<double> const&);
 template closest_point_info closest_point(point<double> const&, point<double> const&);
 template closest_point_info closest_point(line_string<double> const&, point<double> const&);

--- a/src/closest_point_i64.cpp
+++ b/src/closest_point_i64.cpp
@@ -4,6 +4,7 @@
 
 namespace mapbox { namespace geometry { namespace algorithms {
 
+template closest_point_info closest_point(empty const&, point<std::int64_t> const&);
 template closest_point_info closest_point(geometry<std::int64_t> const&, point<std::int64_t> const&);
 template closest_point_info closest_point(point<std::int64_t> const&, point<std::int64_t> const&);
 template closest_point_info closest_point(line_string<std::int64_t> const&, point<std::int64_t> const&);

--- a/test/unit/closest_point/test-closest-point.cpp
+++ b/test/unit/closest_point/test-closest-point.cpp
@@ -10,6 +10,25 @@ void test_closest_point_d()
 {
     using namespace mapbox::geometry;
     namespace op = algorithms;
+    // Point => Empty
+    {
+        empty e;
+        point<double> p1{0.0, 0.0};
+        point<double> p2{3.0, 4.0};
+        {
+            auto result = op::closest_point(e, p2);
+            BOOST_CHECK_CLOSE(result.x, 0.0, 1e-06);
+            BOOST_CHECK_CLOSE(result.y, 0.0, 1e-06);
+            BOOST_CHECK_CLOSE(result.distance, -1.0, 1e-06);
+        }
+        {
+            auto result = op::closest_point(e, p1);
+            BOOST_CHECK_CLOSE(result.x, 0.0, 1e-06);
+            BOOST_CHECK_CLOSE(result.y, 0.0, 1e-06);
+            BOOST_CHECK_CLOSE(result.distance, -1.0, 1e-06);
+        }
+    }
+
     // Point => Point
     {
         point<double> p1{0.0, 0.0};
@@ -112,12 +131,78 @@ void test_closest_point_d()
         BOOST_CHECK_CLOSE(result.y, 3.0, 1e-06);
         BOOST_CHECK_CLOSE(result.distance, std::sqrt(5.0), 1e-03);
     }
+
+    // Point => Geometry
+    {
+        multi_polygon<double> mpoly {
+            {{{0, 0}, {1, 0}, {1, 1}, {0, 1}, {0, 0}}},
+            {{{2, 2}, {3, 2}, {3, 3}, {2, 3}, {2, 2}}}
+        };
+        geometry<double> geom(std::move(mpoly));
+        point<double> pt {4.0, 5.0};
+        auto result = op::closest_point(geom, pt);
+        BOOST_CHECK_CLOSE(result.x, 3.0, 1e-06);
+        BOOST_CHECK_CLOSE(result.y, 3.0, 1e-06);
+        BOOST_CHECK_CLOSE(result.distance, std::sqrt(5.0), 1e-03);
+    }
+    
+    // Point => Geometry Collection
+    {
+        multi_polygon<double> mpoly {
+            {{{0, 0}, {1, 0}, {1, 1}, {0, 1}, {0, 0}}},
+            {{{2, 2}, {3, 2}, {3, 3}, {2, 3}, {2, 2}}}
+        };
+        geometry<double> geom1(std::move(mpoly));
+        geometry<double> geom2; // empty geometry
+        multi_point<double> mp{{-1,-1}, {1, 1}};
+        geometry<double> geom3(std::move(mp));
+        
+        geometry_collection<double> gc;
+        gc.push_back(geom1);
+        gc.push_back(geom2);
+        gc.push_back(geom3);
+
+        point<double> pt {4, 5};
+        auto result = op::closest_point(gc, pt);
+        BOOST_CHECK_CLOSE(result.x, 3.0, 1e-06);
+        BOOST_CHECK_CLOSE(result.y, 3.0, 1e-06);
+        BOOST_CHECK_CLOSE(result.distance, std::sqrt(5.0), 1e-03);
+        
+        geometry_collection<double> gc2;
+        gc2.push_back(geom2); // First is a empty geometry
+        gc2.push_back(geom1);
+        gc2.push_back(geom3);
+        
+        auto result2 = op::closest_point(gc2, pt);
+        BOOST_CHECK_CLOSE(result2.x, 3.0, 1e-06);
+        BOOST_CHECK_CLOSE(result2.y, 3.0, 1e-06);
+        BOOST_CHECK_CLOSE(result2.distance, std::sqrt(5.0), 1e-03);
+    }
 }
 
 void test_closest_point_int64()
 {
     using namespace mapbox::geometry;
     namespace op = algorithms;
+    // Point => Empty
+    {
+        empty e;
+        point<std::int64_t> p1{0, 0};
+        point<std::int64_t> p2{3, 4};
+        {
+            auto result = op::closest_point(e, p2);
+            BOOST_CHECK_CLOSE(result.x, 0.0, 1e-06);
+            BOOST_CHECK_CLOSE(result.y, 0.0, 1e-06);
+            BOOST_CHECK_CLOSE(result.distance, -1.0, 1e-06);
+        }
+        {
+            auto result = op::closest_point(e, p1);
+            BOOST_CHECK_CLOSE(result.x, 0.0, 1e-06);
+            BOOST_CHECK_CLOSE(result.y, 0.0, 1e-06);
+            BOOST_CHECK_CLOSE(result.distance, -1.0, 1e-06);
+        }
+    }
+
     // Point => Point
     {
         point<std::int64_t> p1{0, 0};
@@ -207,7 +292,7 @@ void test_closest_point_int64()
             BOOST_CHECK_CLOSE(result.distance, 0.0, 1e-06);
         }
     }
-     // Point => MultiPolygon
+    // Point => MultiPolygon
     {
         multi_polygon<std::int64_t> mpoly {
             {{{0, 0}, {1, 0}, {1, 1}, {0, 1}, {0, 0}}},
@@ -218,6 +303,53 @@ void test_closest_point_int64()
         BOOST_CHECK_CLOSE(result.x, 3.0, 1e-06);
         BOOST_CHECK_CLOSE(result.y, 3.0, 1e-06);
         BOOST_CHECK_CLOSE(result.distance, std::sqrt(5.0), 1e-03);
+    }
+    
+    // Point => Geometry
+    {
+        multi_polygon<std::int64_t> mpoly {
+            {{{0, 0}, {1, 0}, {1, 1}, {0, 1}, {0, 0}}},
+            {{{2, 2}, {3, 2}, {3, 3}, {2, 3}, {2, 2}}}
+        };
+        geometry<std::int64_t> geom(std::move(mpoly));
+        point<std::int64_t> pt {4, 5};
+        auto result = op::closest_point(geom, pt);
+        BOOST_CHECK_CLOSE(result.x, 3.0, 1e-06);
+        BOOST_CHECK_CLOSE(result.y, 3.0, 1e-06);
+        BOOST_CHECK_CLOSE(result.distance, std::sqrt(5.0), 1e-03);
+    }
+    
+    // Point => Geometry Collection
+    {
+        multi_polygon<std::int64_t> mpoly {
+            {{{0, 0}, {1, 0}, {1, 1}, {0, 1}, {0, 0}}},
+            {{{2, 2}, {3, 2}, {3, 3}, {2, 3}, {2, 2}}}
+        };
+        geometry<std::int64_t> geom1(std::move(mpoly));
+        geometry<std::int64_t> geom2; // empty geometry
+        multi_point<std::int64_t> mp{{-1,-1}, {1, 1}};
+        geometry<std::int64_t> geom3(std::move(mp));
+        
+        geometry_collection<std::int64_t> gc;
+        gc.push_back(geom1);
+        gc.push_back(geom2);
+        gc.push_back(geom3);
+
+        point<std::int64_t> pt {4, 5};
+        auto result = op::closest_point(gc, pt);
+        BOOST_CHECK_CLOSE(result.x, 3.0, 1e-06);
+        BOOST_CHECK_CLOSE(result.y, 3.0, 1e-06);
+        BOOST_CHECK_CLOSE(result.distance, std::sqrt(5.0), 1e-03);
+        
+        geometry_collection<std::int64_t> gc2;
+        gc2.push_back(geom2); // First is a empty geometry
+        gc2.push_back(geom1);
+        gc2.push_back(geom3);
+        
+        auto result2 = op::closest_point(gc2, pt);
+        BOOST_CHECK_CLOSE(result2.x, 3.0, 1e-06);
+        BOOST_CHECK_CLOSE(result2.y, 3.0, 1e-06);
+        BOOST_CHECK_CLOSE(result2.distance, std::sqrt(5.0), 1e-03);
     }
 }
 


### PR DESCRIPTION
Adds an operator for mapbox::geometry::empty, which is partially introduced in a branch of geometry.hpp. Not sure if this deserves to be merged, but currently cannot compile without this change. I'll plan on publishing a dev package to Mason.

cc @flippmoke @artemp  